### PR TITLE
Fixed typo in README (decorator dropping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ def <name>(<parameters>):
 becomes:
 
 ```
-def f(<parameters>):
+def <name>(<parameters>):
   <body>
 <name> = <decorator>(<name>)
 ```


### PR DESCRIPTION
Just a small typo in the description of decorator dropping in README.md.
